### PR TITLE
Add bootstrap classes to FileWarningHeader

### DIFF
--- a/src/SettingsField.php
+++ b/src/SettingsField.php
@@ -9,6 +9,7 @@ use SilverStripe\Forms\CompositeField;
 use SilverStripe\Forms\DropdownField;
 use SilverStripe\Forms\FieldList;
 use SilverStripe\Forms\HeaderField;
+use SilverStripe\Forms\LiteralField;
 use SilverStripe\Forms\TreeDropdownField;
 use SilverStripe\View\Requirements;
 
@@ -42,7 +43,7 @@ class SettingsField extends CompositeField
         Requirements::javascript('silverstripe/documentconverter: javascript/DocumentConversionField.js');
 
         $fields = FieldList::create([
-            HeaderField::create(
+            LiteralField::create(
                 'FileWarningHeader',
                 '<div class="alert alert-warning">' . _t(
                     __CLASS__ . '.FileWarningHeader',

--- a/src/SettingsField.php
+++ b/src/SettingsField.php
@@ -44,10 +44,10 @@ class SettingsField extends CompositeField
         $fields = FieldList::create([
             HeaderField::create(
                 'FileWarningHeader',
-                _t(
+                '<div class="alert alert-warning">' . _t(
                     __CLASS__ . '.FileWarningHeader',
                     'Warning: import will remove all content and subpages of this page.'
-                ),
+                ) . '</div>',
                 4
             ),
             $splitHeader = DropdownField::create(

--- a/tests/SettingsFieldTest.php
+++ b/tests/SettingsFieldTest.php
@@ -9,6 +9,7 @@ use SilverStripe\Forms\CheckboxField;
 use SilverStripe\Forms\DropdownField;
 use SilverStripe\Forms\FieldList;
 use SilverStripe\Forms\HeaderField;
+use SilverStripe\Forms\LiteralField;
 use SilverStripe\Forms\TreeDropdownField;
 use SilverStripe\View\Requirements;
 
@@ -48,7 +49,7 @@ class SettingsFieldTest extends SapphireTest
         $this->assertInstanceOf(FieldList::class, $fields);
 
         // We don't need to check that all of the fields are there, but just check a couple
-        $this->assertInstanceOf(HeaderField::class, $fields->fieldByName('FileWarningHeader'));
+        $this->assertInstanceOf(LiteralField::class, $fields->fieldByName('FileWarningHeader'));
         $innerField = $fields->fieldByName('ImportedFromFile');
         $this->assertInstanceOf(ImportField::class, $innerField);
 


### PR DESCRIPTION
Added bootstrap classes to make the warning stand out more. Fixes #12 

**Note:** I am not able to set up this module locally, so I haven't tested if it actually renders correctly. Do you mind doing that @NightJar, pretty please?