### PR TITLE
FIX Replace Convert JSON methods with json_* methods, deprecated from SilverStripe 4.4

### DIFF
--- a/src/ImportField.php
+++ b/src/ImportField.php
@@ -114,7 +114,7 @@ class ImportField extends UploadField
             }
         }
 
-        $response = HTTPResponse::create(Convert::raw2json([$return]));
+        $response = HTTPResponse::create(json_encode([$return]));
         $response->addHeader('Content-Type', 'application/json');
         return $response;
     }


### PR DESCRIPTION
Issue: https://github.com/silverstripe/silverstripe-framework/issues/8424