### PR TITLE
MNT Revert erroneous dependency changes

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -9,8 +9,8 @@
     ],
     "require": {
         "php": "^7.4 || ^8.0",
-        "silverstripe/cms": "4.13.x-dev",
-        "silverstripe/asset-admin": "1.13.x-dev"
+        "silverstripe/cms": "^4",
+        "silverstripe/asset-admin": "^1"
     },
     "require-dev": {
         "ext-curl": "*",


### PR DESCRIPTION
Bad logic in cow resulted in many non-recipes having their constraints updated automatically when the beta was released.

## Issue
- https://github.com/silverstripe/.github/issues/33