### PR TITLE
FIX Don't use deprecated usage of get_class()

### DIFF
--- a/src/SettingsField.php
+++ b/src/SettingsField.php
@@ -33,7 +33,7 @@ class SettingsField extends CompositeField
     public function __construct($children = null)
     {
         if ($children) {
-            $class = get_class();
+            $class = self::class;
             throw new InvalidArgumentException(
                 "{$class}::__construct does not accept extra parameters."
             );


### PR DESCRIPTION
## Issue
- https://github.com/silverstripe/silverstripe-versionfeed/issues/102