### PR TITLE
MNT Add dev version of framework

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,6 +17,7 @@
         "ext-tidy": "*",
         "ext-zip": "*",
         "phpunit/phpunit": "^9.5",
+        "silverstripe/framework": "^4.10",
         "squizlabs/php_codesniffer": "^3.0"
     },
     "autoload": {


### PR DESCRIPTION
Issue https://github.com/silverstripe/.github/issues/284

Required to use phpunit 9.5 for --prefer-lowest build

https://github.com/silverstripe/silverstripe-documentconverter/actions/runs/9851668649